### PR TITLE
Update workflow dependency installation

### DIFF
--- a/.github/workflows/project-v2-acceptance-testing.yml
+++ b/.github/workflows/project-v2-acceptance-testing.yml
@@ -246,7 +246,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -255,7 +254,7 @@ jobs:
           key: ${{ runner.os }}-ms-playwright-${{ hashFiles('package-lock.json') }}
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm install
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/scheduled-all-tests.yml
+++ b/.github/workflows/scheduled-all-tests.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -30,7 +29,7 @@ jobs:
           key: ${{ runner.os }}-ms-playwright-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps


### PR DESCRIPTION
Remove setup-node npm cache configuration from the Playwright workflows.

Use npm install instead of npm ci in the acceptance and scheduled test pipelines.